### PR TITLE
feat: set process.env directly now that Netlify supports it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const util = require('util');
-const pWriteFile = util.promisify(fs.writeFile);
 
 /**
  * Overrides an ENV var with a value if it exists
@@ -16,10 +15,8 @@ function setEnvWithValue(key, contextOrBranch, mode) {
   }
 
   console.log(`Exporting ${key}=${process.env[envVar]}.`);
+  process.env[key] = process.env[envVar];
 
-  // Renable this once setting process.env is supported in Netlify builds
-  // See: https://github.com/netlify/build/issues/1129
-  // process.env[key] = process.env[envVar];
   return `${key}=${process.env[envVar]}\n`;
 }
 
@@ -27,19 +24,17 @@ module.exports = {
   onPreBuild: async ({ inputs }) => {
     const context = `${process.env.CONTEXT}`.toUpperCase().replace(/-/g, '_');
     const branch = `${process.env.BRANCH}`.toUpperCase().replace(/-/g, '_');
+    const { mode } = inputs;
 
     const envOverrides = Object.keys(process.env).map((key) => [
-      setEnvWithValue(key, context, inputs.mode),
-      setEnvWithValue(key, branch, inputs.mode),
+      setEnvWithValue(key, context, mode),
+      setEnvWithValue(key, branch, mode),
     ]);
 
     const replaced = [].concat(...envOverrides).filter(Boolean);
 
     if (replaced.length) {
-      // Write an env file so we can source it during build
-      await pWriteFile('.env', replaced.join(''));
-
-      console.log(`Replaced ${replaced.length} ENVs and wrote .env file`);
+      console.log(`Replaced ${replaced.length} ENVs`);
     } else {
       console.log(`Nothing found... keeping default ENVs`);
     }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,17 +1,9 @@
-jest.mock('fs');
-const mockWriteFile = jest.fn(() => Promise.resolve());
-
-jest.mock('util', () => ({
-  promisify: () => mockWriteFile,
-}));
-
 const onPreBuild = require('./index').onPreBuild;
 
 describe('onPreBuild', () => {
   const OLD_ENV = process.env;
 
   beforeEach(() => {
-    mockWriteFile.mockReset();
     jest.resetModules();
     process.env = { ...OLD_ENV };
   });
@@ -21,56 +13,57 @@ describe('onPreBuild', () => {
   });
 
   describe('with context prefix ENV overrides', () => {
-    it('writes an env file with updated values', async () => {
+    it('sets ENV vars to the correct values', async () => {
       process.env.DATABASE_URL = 'https://dev.com';
       process.env.STAGING_DATABASE_URL = 'https://stage.com';
       process.env.CONTEXT = 'staging';
       await onPreBuild({ inputs: { mode: 'prefix' } });
 
-      expect(mockWriteFile).toHaveBeenCalledWith('.env', 'DATABASE_URL=https://stage.com\n');
+      expect(process.env.DATABASE_URL).toBe(process.env.STAGING_DATABASE_URL);
     });
   });
 
   describe('with suffix context prefix ENV overrides', () => {
-    it('writes an env file with updated values', async () => {
+    it('sets ENV vars to the correct values', async () => {
       process.env.DATABASE_URL = 'https://dev.com';
       process.env.DATABASE_URL_STAGING = 'https://stage.com';
       process.env.CONTEXT = 'staging';
       await onPreBuild({ inputs: { mode: 'suffix' } });
 
-      expect(mockWriteFile).toHaveBeenCalledWith('.env', 'DATABASE_URL=https://stage.com\n');
+      expect(process.env.DATABASE_URL).toBe(process.env.DATABASE_URL_STAGING);
     });
   });
 
   describe('with branch ENV overrides', () => {
-    it('writes an env file with updated values', async () => {
+    it('sets ENV vars to the correct values', async () => {
       process.env.DATABASE_URL = 'https://dev.com';
       process.env.HELLO_DATABASE_URL = 'https://stage.com';
       process.env.BRANCH = 'hello';
       await onPreBuild({ inputs: { mode: 'prefix' } });
 
-      expect(mockWriteFile).toHaveBeenCalledWith('.env', 'DATABASE_URL=https://stage.com\n');
+      expect(process.env.DATABASE_URL).toBe(process.env.HELLO_DATABASE_URL);
     });
   });
 
   describe('with suffix branch ENV overrides', () => {
-    it('writes an env file with updated values', async () => {
+    it('sets ENV vars to the correct values', async () => {
       process.env.DATABASE_URL = 'https://dev.com';
       process.env.DATABASE_URL_HELLO = 'https://stage.com';
       process.env.BRANCH = 'hello';
       await onPreBuild({ inputs: { mode: 'suffix' } });
 
-      expect(mockWriteFile).toHaveBeenCalledWith('.env', 'DATABASE_URL=https://stage.com\n');
+      expect(process.env.DATABASE_URL).toBe(process.env.DATABASE_URL_HELLO);
     });
   });
 
   describe('without ENV overrides', () => {
-    it('writes an env file with updated values', async () => {
+    it('does not change ENV vars', async () => {
       process.env.DATABASE_URL = 'https://dev.com';
+      process.env.DATABASE_URL_HELLO = 'https://dontsetme.com';
       process.env.BRANCH = 'hello';
-      await onPreBuild({ inputs: { mode: 'prefix' } });
+      await onPreBuild({ inputs: { mode: 'suffix' } });
 
-      expect(mockWriteFile).not.toHaveBeenCalled();
+      expect(process.env.DATABASE_URL).toBe(process.env.DATABASE_URL_HELLO);
     });
   });
 });


### PR DESCRIPTION
This removes the logic to write an env file and instead sets `process.env` directly now that Netlify added support: https://github.com/netlify/build/issues/1129

Fixes #2 